### PR TITLE
ENG-933: Override handlebars to ^4.7.9 (CVE-2026-33937)

### DIFF
--- a/modelcontextprotocol/package.json
+++ b/modelcontextprotocol/package.json
@@ -25,6 +25,7 @@
   },
   "pnpm": {
     "overrides": {
+      "handlebars": "^4.7.9",
       "jsondiffpatch": "0.7.2",
       "langsmith": ">=0.4.6",
       "hono": ">=4.12.7"

--- a/modelcontextprotocol/pnpm-lock.yaml
+++ b/modelcontextprotocol/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  handlebars: ^4.7.9
   jsondiffpatch: 0.7.2
   langsmith: '>=0.4.6'
   hono: '>=4.12.7'
@@ -1359,8 +1360,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -4192,7 +4193,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -5374,7 +5375,7 @@ snapshots:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       jest: 29.7.0(@types/node@22.19.13)(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -70,6 +70,7 @@
   },
   "pnpm": {
     "overrides": {
+      "handlebars": "^4.7.9",
       "langsmith": ">=0.4.6",
       "hono": ">=4.12.7"
     }

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  handlebars: ^4.7.9
   langsmith: '>=0.4.6'
   hono: '>=4.12.7'
 
@@ -121,7 +122,7 @@ importers:
         version: 16.6.1
       langchain:
         specifier: ^0.3.37
-        version: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(zod@3.25.76)))(@opentelemetry/api@1.9.0)(handlebars@4.7.8)(openai@4.104.0(zod@3.25.76))
+        version: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(zod@3.25.76)))(@opentelemetry/api@1.9.0)(handlebars@4.7.9)(openai@4.104.0(zod@3.25.76))
     devDependencies:
       '@types/node':
         specifier: ^22.7.4
@@ -1778,8 +1779,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -2235,7 +2236,7 @@ packages:
       '@langchain/xai': '*'
       axios: '*'
       cheerio: '*'
-      handlebars: ^4.7.8
+      handlebars: ^4.7.9
       peggy: ^3.0.2
       typeorm: '*'
     peerDependenciesMeta:
@@ -5030,7 +5031,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -5637,7 +5638,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(zod@3.25.76)))(@opentelemetry/api@1.9.0)(handlebars@4.7.8)(openai@4.104.0(zod@3.25.76)):
+  langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(zod@3.25.76)))(@opentelemetry/api@1.9.0)(handlebars@4.7.9)(openai@4.104.0(zod@3.25.76)):
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(zod@3.25.76))
       '@langchain/openai': 0.3.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(zod@3.25.76)))
@@ -5652,7 +5653,7 @@ snapshots:
       yaml: 2.8.2
       zod: 3.25.76
     optionalDependencies:
-      handlebars: 4.7.8
+      handlebars: 4.7.9
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -6340,7 +6341,7 @@ snapshots:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       jest: 29.7.0(@types/node@22.19.13)(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
## Summary
- Adds `pnpm.overrides` for `handlebars: "^4.7.9"` in both `typescript/` and `modelcontextprotocol/` workspaces
- Fixes CVE-2026-33937 (CRITICAL, CVSS 9.8, Vanta SLA due 2026-04-12)
- Handlebars is a transitive dependency — the override forces resolution to the patched version

## Test plan
- [ ] Verify `cd typescript && pnpm install` succeeds
- [ ] Verify `cd modelcontextprotocol && pnpm install` succeeds
- [ ] Run tests in both workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)