### PR TITLE
ENG-1048: Drop redundant handlebars / hono pnpm overrides (stacked)

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -70,9 +70,7 @@
   },
   "pnpm": {
     "overrides": {
-      "handlebars": "^4.7.9",
       "langsmith": ">=0.4.6",
-      "hono": ">=4.12.7",
       "flatted": ">=3.4.2"
     }
   },

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -5,9 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  handlebars: ^4.7.9
   langsmith: '>=0.4.6'
-  hono: '>=4.12.7'
   flatted: '>=3.4.2'
 
 importers:
@@ -2237,7 +2235,7 @@ packages:
       '@langchain/xai': '*'
       axios: '*'
       cheerio: '*'
-      handlebars: ^4.7.9
+      handlebars: ^4.7.8
       peggy: ^3.0.2
       typeorm: '*'
     peerDependenciesMeta:


### PR DESCRIPTION
## 🔧 Change Summary

Stacked on top of #23. Drops two now-redundant entries from \`pnpm.overrides\`:

| override | floor | natural | status |
|---|---|---|---|
| \`handlebars ^4.7.9\` | 4.7.9 | 4.7.9 | redundant |
| \`hono >=4.12.7\` | 4.12.7 | 4.12.14 | redundant (matches the cluster-4 bump in #23) |

Remaining overrides stay:
- \`langsmith >=0.4.6\` — without it, \`0.3.87\` reappears alongside \`0.5.11\`.
- \`flatted >=3.4.2\` (introduced in #23) — without it, \`flat-cache@4.0.1\` pins \`flatted: 3.3.4\` in the lockfile.

## 📋 Linked Linear Ticket
- references ENG-1048

## 🧪 How Was This Tested?
- Removed each candidate, ran \`pnpm install --lockfile-only\`, confirmed no version regressions.

## 🔐 Security Consideration
No regression. All previously-floored packages remain at or above the CVE fix versions.

## ⚠️ Merge order
Merge **after #23** (this PR is stacked on it). GitHub will rebase the diff cleanly once #23 is in.

## 🚀 Deployment & Validation Plan
- **Deployment Method:** Merge → existing release pipeline.
- **Target Environment:** npm publish.
- **Post-Deployment Validation Steps:** None expected; same resolved versions.

## 🔁 Rollback Plan
Revert this commit.

## 📄 Change Type
- [x] Dependency update (cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)