### PR TITLE
ENG-1247: Notify #github-actions on workflow failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,6 +131,7 @@ jobs:
 
   notify-failure:
     needs: [typescript-build, modelcontextprotocol-build, python-build]
+    permissions: {}
     if: ${{ failure() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,3 +128,31 @@ jobs:
           make clean
           make build
           make check-build
+
+  notify-failure:
+    needs: [typescript-build, modelcontextprotocol-build, python-build]
+    if: ${{ failure() && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_CI_WEBHOOK_URL: ${{ secrets.SLACK_CI_WEBHOOK_URL }}
+        run: |
+          if [[ -z "${SLACK_CI_WEBHOOK_URL:-}" ]]; then
+            echo "SLACK_CI_WEBHOOK_URL not set; skipping notify"
+            exit 0
+          fi
+          short_sha="${GITHUB_SHA:0:7}"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+          jq -n \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg workflow "$GITHUB_WORKFLOW" \
+            --arg branch "$GITHUB_REF_NAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg short_sha "$short_sha" \
+            --arg commit_url "$commit_url" \
+            --arg run_url "$run_url" \
+            '{text: (":rotating_light: *" + $repo + "* — workflow `" + $workflow + "` failed on `" + $branch + "`\nCommit: <" + $commit_url + "|`" + $short_sha + "`> by " + $actor + "\nRun: <" + $run_url + "|view logs>")}' \
+            | curl -sS -X POST -H 'Content-Type: application/json' --data @- "$SLACK_CI_WEBHOOK_URL" >/dev/null \
+            || echo "WARNING: Slack post failed" >&2


### PR DESCRIPTION
## Summary
- Adds a `notify-failure` job to `main.yml` posting to **#github-actions** via `SLACK_CI_WEBHOOK_URL` (org-level secret) when any job fails on push to main.
- PR-trigger failures excluded via guard.
- No-ops cleanly if the secret isn't set.
- Part of ENG-1247 cross-repo rollout.

## Linked Linear Ticket
- references ENG-1247

## Test plan
- [ ] Once `SLACK_CI_WEBHOOK_URL` org secret is set, force a failure on main and confirm the message lands in #github-actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)